### PR TITLE
Cleaning and adding flag disable-dev-shm-usage

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-COMPOSE_PROJECT_NAME=snap
+COMPOSE_PROJECT_NAME=chromeheadless
 
 ADDR=127.0.0.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ WORKDIR $WORKDIR
 
 COPY . .
 
-RUN mkdir -p /srv/www /root /var/run/s6 /etc/services.d/snap && \
-    cp docker/run_snap /etc/services.d/snap/run && \
+RUN mkdir -p /srv/www /root /var/run/s6 /etc/services.d/chromeheadless && \
+    cp docker/run_chromeheadless /etc/services.d/chromeheadless/run && \
     curl -s https://dl-ssl.google.com/linux/linux_signing_key.pub -o linux_signing_key.pub && \
     apt-key add linux_signing_key.pub && \
     echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.1'
 
 services:
-  snap:
+  chromeheadless:
     image: unocha/snap-service:$IMAGE_TAG
     ports:
       - "$ADDR:9222:9222"

--- a/docker/run_chromeheadless
+++ b/docker/run_chromeheadless
@@ -1,0 +1,5 @@
+#!/usr/bin/with-contenv sh
+
+cd $WORKDIR
+
+exec s6-setuidgid appuser google-chrome --headless --disable-gpu --remote-debugging-port=9222 --remote-debugging-address=0.0.0.0 --no-sandbox --disable-dev-shm-usage

--- a/docker/run_snap
+++ b/docker/run_snap
@@ -1,5 +1,0 @@
-#!/usr/bin/with-contenv sh
-
-cd $WORKDIR
-
-exec s6-setuidgid appuser google-chrome -headless --disable-gpu --disable-extensions --disable-translate --hide-scrollbars --remote-debugging-port=9222 --remote-debugging-address=0.0.0.0 --no-sandbox


### PR DESCRIPTION
I have added the flag disable-dev-shm-usage as suggested by @cafuego which seems to address the performance issue we have been confront with.

I did some renaming from snap to chromeheadless to avoid confusion as well.