### PR TITLE
Adds --disable-dev-shm-usage to startup flags

### DIFF
--- a/docker/run_snap
+++ b/docker/run_snap
@@ -2,4 +2,4 @@
 
 cd $WORKDIR
 
-exec s6-setuidgid appuser google-chrome -headless --disable-gpu --disable-extensions --disable-translate --hide-scrollbars --remote-debugging-port=9222 --remote-debugging-address=0.0.0.0 --no-sandbox
+exec s6-setuidgid appuser google-chrome -headless --disable-gpu --disable-extensions --disable-translate --hide-scrollbars --remote-debugging-port=9222 --remote-debugging-address=0.0.0.0 --no-sandbox --disable-dev-shm-usage


### PR DESCRIPTION
Without this flag I get reliable page crashes when using puppeteer in Insight. In the pre-0.1.0 versions of this image, that flag has also been set. Was there any reason why it has been removed from the startup flags in later versions?

My problem seems to be this: https://github.com/puppeteer/puppeteer/issues/1321

I have also read through parts of [this thread](https://github.com/puppeteer/puppeteer/issues/1834) on why enabling this flag might have negative side effects because chromium will then use /tmp instead of a ram.
